### PR TITLE
Load LiDAR overlay hotspots from Figma SVG

### DIFF
--- a/Website Core/Skeleton/index.html
+++ b/Website Core/Skeleton/index.html
@@ -26,33 +26,7 @@
         <div id="main-panel">
             <!-- LiDAR Board Interface -->
             <div id="lidar-board">
-                <!-- Interactive hotspots - CORRECTED coordinates to match red outlined areas -->
-                <!-- Hotspot 1: Left workspace area (red rectangle on left side) -->
-                <div class="hotspot" data-area="workspace-left" data-coords="240,340,120,80" data-rotation="0"></div>
-                
-                <!-- Hotspot 2: Lower left workspace area -->
-                <div class="hotspot" data-area="workspace-lower" data-coords="380,420,140,90" data-rotation="0"></div>
-                
-                <!-- Hotspot 3: Central area workspace -->
-                <div class="hotspot" data-area="central-workspace" data-coords="760,450,180,100" data-rotation="0"></div>
-                
-                <!-- Hotspot 4: Right central area (upper red rectangle) -->
-                <div class="hotspot" data-area="research-upper" data-coords="1180,180,200,120" data-rotation="0"></div>
-                
-                <!-- Hotspot 5: Right central area (lower red rectangle) -->
-                <div class="hotspot" data-area="research-lower" data-coords="1200,320,180,100" data-rotation="0"></div>
-                
-                <!-- Hotspot 6: Digital workspace center -->
-                <div class="hotspot" data-area="digital-center" data-coords="900,540,160,110" data-rotation="0"></div>
-                
-                <!-- Hotspot 7: Exhibition area right -->
-                <div class="hotspot" data-area="exhibition-right" data-coords="1280,580,180,130" data-rotation="0"></div>
-                
-                <!-- Hotspot 8: Archive section upper left -->
-                <div class="hotspot" data-area="archive-upper" data-coords="320,250,100,70" data-rotation="0"></div>
-                
-                <!-- Hotspot 9: Studio space far right -->
-                <div class="hotspot" data-area="studio-right" data-coords="1480,480,160,90" data-rotation="0"></div>
+                <!-- Hotspots dynamically loaded from SVG references -->
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Dynamically generate LiDAR hotspots by parsing `hover and button locations.svg`
- Replace static hotspot markup with SVG-driven overlay regions
- Recalculate hotspot positions on resize by reloading the SVG
- Skip Git LFS placeholder assets when loading models to avoid JSON parse errors

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f7c900308332bb02a4acc00d2c47