### PR TITLE
Fix local model loading paths to prevent CORS errors

### DIFF
--- a/Website Core/Skeleton/script.js
+++ b/Website Core/Skeleton/script.js
@@ -106,17 +106,18 @@ function loadModel() {
     let modelsLoaded = 0;
     
     // Use local models directory - no CORS issues
+    const modelsBasePath = new URL('./models/', import.meta.url);
     const modelsToLoad = [
-        { name: 'Architectural System', file: './models/arch_module_smallest.glb', isInstanced: true },
-        { name: 'Misc Geometry', file: './models/misc geometry.glb', isInstanced: false },
-        { name: 'Altars', file: './models/altars.glb', isInstanced: false },
-        { name: 'Circulation', file: './models/circulation.glb', isInstanced: false },
-        { name: 'Distress', file: './models/Distress.glb', isInstanced: false },
-        { name: 'Embellishments', file: './models/embellishments.glb', isInstanced: false },
-        { name: 'Index', file: './models/Index.glb', isInstanced: false },
-        { name: 'Mirror', file: './models/mirror.glb', isInstanced: false },
-        { name: 'Moulage', file: './models/Moulage.glb', isInstanced: false },
-        { name: 'Robot', file: './models/robot.glb', isInstanced: false }
+        { name: 'Architectural System', file: new URL('arch_module_smallest.glb', modelsBasePath).href, isInstanced: true },
+        { name: 'Misc Geometry', file: new URL('misc geometry.glb', modelsBasePath).href, isInstanced: false },
+        { name: 'Altars', file: new URL('altars.glb', modelsBasePath).href, isInstanced: false },
+        { name: 'Circulation', file: new URL('circulation.glb', modelsBasePath).href, isInstanced: false },
+        { name: 'Distress', file: new URL('Distress.glb', modelsBasePath).href, isInstanced: false },
+        { name: 'Embellishments', file: new URL('embellishments.glb', modelsBasePath).href, isInstanced: false },
+        { name: 'Index', file: new URL('Index.glb', modelsBasePath).href, isInstanced: false },
+        { name: 'Mirror', file: new URL('mirror.glb', modelsBasePath).href, isInstanced: false },
+        { name: 'Moulage', file: new URL('Moulage.glb', modelsBasePath).href, isInstanced: false },
+        { name: 'Robot', file: new URL('robot.glb', modelsBasePath).href, isInstanced: false }
     ];
     
     const totalModels = modelsToLoad.length;


### PR DESCRIPTION
## Summary
- Load GLB models from the repository's local `models` directory using relative URLs to avoid CORS issues.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689917be0a348332a4bbd9e860b68c34